### PR TITLE
replace weekly_working_hours to actual_weekly_working_hours

### DIFF
--- a/app/controllers/wktime_controller.rb
+++ b/app/controllers/wktime_controller.rb
@@ -619,10 +619,10 @@ end
 	end
 	
 	def total_all_days
-		#((total*5)/User.current.weekly_working_hours)
+		#((total*5)/User.current.actual_weekly_working_hours)
 		 result = 0
 		if @entries.count > 0
-			result = @entries.map{ |entry| (entry.hours * 5)/User.find(entry.user_id).weekly_working_hours }.sum.round(2)
+			result = @entries.map{ |entry| (entry.hours * 5)/entry.user.actual_weekly_working_hours }.sum.round(2)
 			return result
 		else
 			return result

--- a/app/views/wktime/_edit_header.html.erb
+++ b/app/views/wktime/_edit_header.html.erb
@@ -11,7 +11,7 @@
 	<th><%=l(:field_user)%></th>
 	<td><%=h @user.login %>
 		<%=h hidden_field_tag('user_id', @user.id) %>
-		<%=h hidden_field_tag('userWorkingHoursId', @user.weekly_working_hours) %>
+		<%=h hidden_field_tag('userWorkingHoursId', @user.actual_weekly_working_hours) %>
 		<%=h hidden_field_tag('logTimeInDaysId', @user.pref[:logTimeInDays]) %>
 		<%=h hidden_field_tag('exceedLogTimeLimitId', @user.pref[:exceedLogTimeLimit]) %>
 		<%=h hidden_field_tag('editUrlId', "edit?startday=#{@startday}&tab=#{params[:tab]}&user_id=#{@user.id}") %>

--- a/app/views/wktime/_edit_hours.html.erb
+++ b/app/views/wktime/_edit_hours.html.erb
@@ -32,7 +32,7 @@
 				:disabled => disable,
 				:onchange => "validateTotal(this, #{@wday_index},#{controller.maxHour});") %>
 
-				<input type=<%if controller.logInDaysCondition(@user.id) %>"number"<% else %>"hidden"<% end %> name="day<%=@row.to_s()%>[]" id="day<%=@row.to_s()%>_" min="0" max=<% if @user.pref[:exceedLogTimeLimit] == "0" %>"1"<% else %>"2"<% end %> step="<%= controller.dayGranularity %>" value=<% if entry.nil? || @prev_template %>'' <% else%><%= ("%.2f" % ((entry.hours*5)/entry.user.weekly_working_hours)) %> <%end %> style=<%if controller.logInDaysCondition(@user.id) %>"display: initial;"<% else %>"display: none;"<% end %> <% if disable %> disabled <% end %> onchange="updateTablefromDayEntry(this, <%=@wday_index%>);" >
+				<input type=<%if controller.logInDaysCondition(@user.id) %>"number"<% else %>"hidden"<% end %> name="day<%=@row.to_s()%>[]" id="day<%=@row.to_s()%>_" min="0" max=<% if @user.pref[:exceedLogTimeLimit] == "0" %>"1"<% else %>"2"<% end %> step="<%= controller.dayGranularity %>" value=<% if entry.nil? || @prev_template %>'' <% else%><%= ("%.2f" % ((entry.hours*5)/entry.user.actual_weekly_working_hours)) %> <%end %> style=<%if controller.logInDaysCondition(@user.id) %>"display: initial;"<% else %>"display: none;"<% end %> <% if disable %> disabled <% end %> onchange="updateTablefromDayEntry(this, <%=@wday_index%>);" >
 
 				<%=h hidden_field_tag('ids' + @row.to_s() +'[]', entry.nil? || @prev_template ? '' : entry.id) %>
 				<%=h hidden_field_tag('disabled' + @row.to_s() +'[]', disable ) %>

--- a/app/views/wktime/_edit_issues.html.erb
+++ b/app/views/wktime/_edit_issues.html.erb
@@ -106,7 +106,7 @@ user = nil
 				<% if !controller.logInDaysCondition(@user.id) %> 
 				style="display: none;"<% else %> style="display: initial; "
 				<% end %>
-				> <%= ("%.2f" % ((th*5)/@user.weekly_working_hours)) %>  </span> <% if params[:controller] == "wktime" %>
+				> <%= ("%.2f" % ((th*5)/@user.actual_weekly_working_hours)) %>  </span> <% if params[:controller] == "wktime" %>
 			<% if controller.logInDaysCondition(@user.id) %> day<% else %> hours<% end %><% end %>
 		</td>
 	<% end %>
@@ -115,7 +115,7 @@ user = nil
 				style="display: none;"<% else %> style="display: initial; "
 				<% end %>> <%= ("%.2f" % @total_hours) %> </span><span id="total_days" <% if controller.logInDaysCondition(@user.id) %> 
 				style="display: initial;"<% else %> style="display: none; "
-				<% end %>><%= ("%.2f" % ((@total_hours*5)/@user.weekly_working_hours)) %>
+				<% end %>><%= ("%.2f" % ((@total_hours*5)/@user.actual_weekly_working_hours)) %>
 	</span><% if params[:controller] == "wktime" %><% if controller.logInDaysCondition(@user.id) %> days<% else %> hours<% end %><% end %> </b>
 	<%=h hidden_field_tag('total', ("%.2f" % @total_hours) ) %>
 	<%=h hidden_field_tag('unit', currencySym) %>

--- a/app/views/wktime/_list.html.erb
+++ b/app/views/wktime/_list.html.erb
@@ -25,7 +25,7 @@
 <td class="start_date"><%=h format_date(entry.spent_on) %></td>
 <td class="user"><%=h entry.user.login %></td>
 
-<td  class="user"><% if controller.logInDaysCondition(User.current.id) %><%- result=(5*entry.hours)/entry.user.weekly_working_hours %><%= ("%.2f" % result) %> <% else %> <%= controller.getUnit(entry) %>&nbsp;<%=h html_hours("%.2f" % entry.hours) %> <% end %></td>
+<td  class="user"><% if controller.logInDaysCondition(User.current.id) %><%- result=(5*entry.hours)/entry.user.actual_weekly_working_hours %><%= ("%.2f" % result) %> <% else %> <%= controller.getUnit(entry) %>&nbsp;<%=h html_hours("%.2f" % entry.hours) %> <% end %></td>
 
 <td class="status"><%=h statusString(entry.status) unless entry.status.blank? %></td>
 <td align="center">


### PR DESCRIPTION
a new field has been created 'overall_percent_alloc' to precise the real weekly working hours depending of the contract of the employee (part time or full time contract)
if it is part time, the value of overall_percent_alloc will be up to 50 and full time contract 100
This field has been created in leave-management-plugin at redmine_leaves_holidays
